### PR TITLE
Enhance confidence scores

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -230,27 +230,32 @@ function checkQueryType(text, hit) {
  */
 function propMatch(textProp, hitProp, expectEnriched) {
 
-  // both missing, but expect to have enriched value in result => BAD
-  if (check.undefined(textProp) && check.undefined(hitProp) && check.assigned(expectEnriched)) { return 0; }
+  // both missing = match
+  if (check.undefined(textProp) && check.undefined(hitProp)) {
+    if (check.assigned(expectEnriched)) { return 0.5; }
+    else { return 0.8; } // no enrichment expected => GOOD
+  }
 
-  // both missing, and no enrichment expected => GOOD
-  if (check.undefined(textProp) && check.undefined(hitProp)) { return 1; }
+  // text has it, result missing
+  if (check.assigned(textProp) && check.undefined(hitProp)) {
+    if (check.assigned(expectEnriched)) { return 0.2; }
+    else { return 0.4; }
+  }
 
-  // text has it, result doesn't => BAD
-  if (check.assigned(textProp) && check.undefined(hitProp)) { return 0; }
+  // text missing, result has it
+  if (check.undefined(textProp) && check.assigned(hitProp)) {
+    if (check.assigned(expectEnriched)) { return 0.8; }
+    else { return 0.5; }
+  }
 
-  // text missing, result has it, and enrichment is expected => GOOD
-  if (check.undefined(textProp) && check.assigned(hitProp) && check.assigned(expectEnriched)) { return 1; }
+  // both present
 
-  // text missing, result has it, enrichment not desired => 50/50
-  if (check.undefined(textProp) && check.assigned(hitProp)) { return 0.5; }
+  if (textProp.toString().toLowerCase() === hitProp.toString().toLowerCase()) {
+    return 1; //values match
+  }
 
-  // both present, values match => GREAT
-  if (check.assigned(textProp) && check.assigned(hitProp) &&
-      textProp.toString().toLowerCase() === hitProp.toString().toLowerCase()) { return 1; }
-
-  // ¯\_(ツ)_/¯
-  return 0.7;
+  // both present, values differ => BAD regardless of enrichment
+  return 0;
 }
 
 /**

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -1,7 +1,6 @@
-
 /**
  *
- *Basic confidence score should be computed and returned for each item in the results.
+ * Basic confidence score should be computed and returned for each item in the results.
  * The score should range between 0-1, and take into consideration as many factors as possible.
  *
  * Some factors to consider:
@@ -94,7 +93,6 @@ function computeConfidenceScore(req, mean, stdev, hit) {
     hit.confidence += checkAdmin(req.clean.parsed_text, hit);
     checkCount++;
   }
-
   // TODO: look at categories and location
 
   hit.confidence /= checkCount;
@@ -140,13 +138,14 @@ function checkDistanceFromMean(score, mean, stdev) {
   return (score - mean) > stdev ? 1 : 0;
 }
 
+
 // should be improved to handle better complex names such as '5th forest rd'
 function normalizeName(text) {
   return text.toLowerCase().replace(/[0-9]/g, '').trim();
 }
 
 /**
- * Compare text string against all language versions of a property
+ * Compare text string against configuration defined language versions of a property
  *
  * @param {string} text
  * @param {object} property with language versions
@@ -193,7 +192,7 @@ function checkName(text, parsed_text, hit) {
 }
 
 /**
- * text being set indicates the query was for an address
+ * text.number being set indicates the query was for an address
  * check if house number was specified and found in result
  *
  * @param {object|undefined} text

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -72,7 +72,7 @@ function computeScores(req, res, next) {
 function computeConfidenceScore(req, mean, stdev, hit) {
   var dealBreakers = checkForDealBreakers(req, hit);
   if (dealBreakers) {
-    hit.confidence = 0.5;
+    hit.confidence = 0.1;
     return hit;
   }
 

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -131,7 +131,7 @@ module.exports.tests.confidenceScore = function(test, common) {
 
     confidenceScore(req, res, function() {});
     t.equal(res.data[0].confidence, 0.6, 'Internationalized name contributed in scoring');
-    t.equal(res.data[1].confidence, 0.54, 'Do not consider name versions excluded from configuration');
+    t.equal(res.data[1].confidence, 0.4, 'Do not consider name versions excluded from configuration');
 
     t.end();
   });


### PR DESCRIPTION
Elasticsearch multi_match gives sometimes strange scores. It seems to be possible to fix scoring errors by assigning better confidence scores in Pelias api. This PR improves scoring system in many ways. Regression test bench shows that enhanced scores improve geocoding quality by 1%-2%.

An example: search Kilo, Espoo returned Peshawar, Espoo before the scoring boost. Now the first result is Kilo, Espoo, as expected.