### PR TITLE
Sort equally good results by  distance from focus point

### DIFF
--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -71,6 +71,9 @@ function compareResults(a, b) {
   if (b.confidence !== a.confidence) {
     return b.confidence - a.confidence;
   }
+  if (a.distance !== b.distance) {  // focus point defined
+    return b.distance - a.distance;
+  }
   var diff;
   if (a.parent && b.parent) {
     diff = compareProperty(a.parent.localadmin, b.parent.localadmin);

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -72,7 +72,7 @@ function compareResults(a, b) {
     return b.confidence - a.confidence;
   }
   if (a.distance !== b.distance) {  // focus point defined
-    return b.distance - a.distance;
+    return a.distance - b.distance;
   }
   var diff;
   if (a.parent && b.parent) {

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -29,9 +29,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'focus:function': 'linear',
   'focus:offset': '0km',
-  'focus:scale': '50km',
+  'focus:scale': '20km',
   'focus:decay': 0.5,
-  'focus:weight': 2,
+  'focus:weight': 100,
 
   'function_score:score_mode': 'avg',
   'function_score:boost_mode': 'replace',
@@ -92,6 +92,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'population:field': 'population',
   'population:modifier': 'log1p',
   'population:max_boost': 20,
-  'population:weight': 2
+  'population:weight': 2,
+
+  'boost:address': 10,
+  'boost:street': 5
 
 });

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -29,9 +29,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'focus:function': 'linear',
   'focus:offset': '0km',
-  'focus:scale': '20km',
+  'focus:scale': '50km',
   'focus:decay': 0.5,
-  'focus:weight': 100,
+  'focus:weight': 2,
 
   'function_score:score_mode': 'avg',
   'function_score:boost_mode': 'replace',
@@ -92,9 +92,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'population:field': 'population',
   'population:modifier': 'log1p',
   'population:max_boost': 20,
-  'population:weight': 2,
-
-  'boost:address': 10,
-  'boost:street': 5
+  'population:weight': 2
 
 });


### PR DESCRIPTION
Search results are now sorted secondarily by the distance from the focus point, if the focus is defined. Distance does not contribute in the actual confidence score, so it has significance only when matches are equally good. For example, 'R-kioski, helsinki' finds tens of matches, and in this case the closest is returned first. 