### PR TITLE
Show best match name version for all results

### DIFF
--- a/middleware/translate.js
+++ b/middleware/translate.js
@@ -26,7 +26,6 @@ function translate(req, res, next) {
   var lang, matched;
   if (req.clean) {
     lang = req.clean.lang;
-    matched =  req.clean.matched;
   }
 
   if( lang && translations[lang] ) {
@@ -42,18 +41,14 @@ function translate(req, res, next) {
   }
 
   _.forEach(res.data, function(place) {
-    translateName(place, lang, matched);
+    translateName(place, lang);
   });
 
   next();
 }
 
-function translateName(place, lang, matched) {
+function translateName(place, lang) {
   if( place.name ) {
-    if( matched && place.name[matched] ) {
-      // store also name version which gave best match
-      place.altName = place.name[matched];
-    }
     if( place.name[lang] ) {
       place.name = place.name[lang];
     } else if (place.name.default) { // fallback

--- a/middleware/translate.js
+++ b/middleware/translate.js
@@ -16,6 +16,33 @@ function setup() {
   return translate;
 }
 
+function translateName(place, lang) {
+  if( place.name ) {
+    if( place.name[lang] ) {
+      place.name = place.name[lang];
+    } else if (place.name.default) { // fallback
+      place.name = place.name.default;
+    }
+  }
+}
+
+function translateProperties(place, key, names) {
+  if( place[key] !== null ) {
+    var name;
+    if (place[key] instanceof Array) {
+      name = place[key][0];
+      if (name && names[name]) {
+        place[key][0] = names[name]; // do the translation
+      }
+    } else {
+      name = place[key];
+      if (name && names[name]) {
+        place[key] = names[name];
+      }
+    }
+  }
+}
+
 function translate(req, res, next) {
 
   // do nothing if no result data set
@@ -45,34 +72,6 @@ function translate(req, res, next) {
   });
 
   next();
-}
-
-function translateName(place, lang) {
-  if( place.name ) {
-    if( place.name[lang] ) {
-      place.name = place.name[lang];
-    } else if (place.name.default) { // fallback
-      place.name = place.name.default;
-    }
-  }
-}
-
-
-function translateProperties(place, key, names) {
-  if( place[key] !== null ) {
-    var name;
-    if (place[key] instanceof Array) {
-      name = place[key][0];
-      if (name && names[name]) {
-        place[key][0] = names[name]; // do the translation
-      }
-    } else {
-      name = place[key];
-      if (name && names[name]) {
-        place[key] = names[name];
-      }
-    }
-  }
 }
 
 module.exports = setup;

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -28,7 +28,7 @@
     "sizePadding": 6,
     "minConfidence": 0.2,
     "relativeMinConfidence": 0.4,
-    "languageMatchThreshold": 0.25,
+    "languageMatchThreshold": 0.4,
     "query": {
       "search": {
         "disableFallback": true,


### PR DESCRIPTION
Label part of the search result now always includes the name version, which matches best with the search string. Previously this happened only when best match with alt name was in 1st result, and only using the same best match selection.

Example: search 'sta, helsinki' matches best name.local. 

Before:
Helsinki (Stadi), Helsinki
Kaupungintalo, Helsinki
Kottaraistie 3326, Helsinki

Now:
Helsinki (Stadi), Helsinki
Kaupungintalo (Stadshuset), Helsinki
Kottaraistie 3326  (Starvägen 3326), Helsinki

This makes it apparent why each result is included in the result list.
