### PR TITLE
Make pelias search more flexible about address and name format

### DIFF
--- a/helper/labelGenerator.js
+++ b/helper/labelGenerator.js
@@ -47,6 +47,10 @@ function getSchema(country_a) {
 
 }
 
+function normalize(str) {
+  return str.toLowerCase().replace(/ /g, '');
+}
+
 // helper function that sets a default label
 function getInitialLabel(record) {
 
@@ -58,7 +62,8 @@ function getInitialLabel(record) {
     return [record.expandedName];
   }
 
-  if (record.altName && record.altName !== record.name && record.name.indexOf(record.altName)===-1) {
+  if (record.altName && record.altName !== record.name &&
+    normalize(record.name).indexOf(normalize(record.altName))===-1) {
     return [record.name +' ('+ record.altName +')'];
   }
 

--- a/helper/labelGenerator.js
+++ b/helper/labelGenerator.js
@@ -28,11 +28,10 @@ function dedupeNameAndFirstLabelElement(labelParts) {
     // first, dedupe the name and 1st label array elements
     //  this is used to ensure that the `name` and first admin hierarchy elements aren't repeated
     //  eg - `["Lancaster", "Lancaster", "PA", "United States"]` -> `["Lancaster", "PA", "United States"]`
-    var deduped = _.uniq([labelParts.shift(), labelParts.shift()]);
 
-    // second, unshift the deduped parts back onto the labelParts
-    labelParts.unshift.apply(labelParts, deduped);
-
+    if (labelParts[0].toLowerCase() === labelParts[1].toLowerCase()) {
+      labelParts.splice(1, 1);
+    }
   }
 
   return labelParts;

--- a/helper/labelGenerator.js
+++ b/helper/labelGenerator.js
@@ -11,7 +11,10 @@ module.exports = function( record, req ){
   // iterate the schema
   for (var field in schema) {
     var valueFunction = schema[field];
-    labelParts.push(valueFunction(record, req));
+    var value = valueFunction(record, req);
+    if(value) {
+      labelParts.push(value);
+    }
   }
 
   // retain only things that are truthy

--- a/helper/labelSchema.js
+++ b/helper/labelSchema.js
@@ -15,7 +15,11 @@ if (api && api.localization && api.localization.labelSchemas) {
   for (var country in imported) {
     var schema = imported[country];
     for (var key in schema) { // convert to the convention above
-      schema[key] = getFirstProperty(schema[key].fields, schema[key].matchType); // param array to func
+      schema[key] = getFirstProperty(  // param array to func
+        schema[key].fields,
+        schema[key].matchType,
+        schema[key].targets
+      );
     }
     schemas[country] = schema;
   }
@@ -31,9 +35,12 @@ function baseVal(val) {
 }
 
 // find the first field of record that has a non-empty value that's not already in labelParts
-function getFirstProperty(fields, matchType) {
+function getFirstProperty(fields, matchType, targets) {
   return function(record, req) {
 
+    if (targets && targets.indexOf(record.layer)===-1) {
+      return null; // not applicable to this kind of record
+    }
     var matchRegions;
     if(matchType==='best' && req && req.clean && req.clean.parsed_text &&
        req.clean.parsed_text.regions && req.clean.parsed_text.regions.length>0) {
@@ -72,5 +79,4 @@ function getFirstProperty(fields, matchType) {
     }
     return bestField;
   };
-
 }

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -450,11 +450,11 @@ function checkAdmin(values, hit) {
 
   values.forEach(function(value) {
     var best=0, weight = 1;
-    var nvalue = normalize(value);
+    var nvalue = normalize(removeNumbers(value));
 
     // loop trough configured properties to find best match
     for(var key in adminWeights) {
-      var prop = hit.parent[key];
+      var prop = (key === 'street' && hit.address_parts) ? hit.address_parts.street : hit.parent[key];
       if (prop) {
         var match;
         if ( Array.isArray(prop) ) {

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -324,12 +324,14 @@ function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
  */
 function checkName(text, parsedText, hit) {
 
+  var isVenue = hit.layer === 'venue' || hit.layer === 'stop' || hit.layer === 'station';
+
   // parsedText name should take precedence if available since it's the cleaner name property
   if (check.assigned(parsedText) && check.assigned(parsedText.name)) {
     var name = parsedText.name;
-      var bestScore = checkLanguageNames(name, hit, false, true);
+      var bestScore = checkLanguageNames(name, hit, false, isVenue);
 
-    if (parsedText.regions) {
+    if (parsedText.regions && isVenue) {
       // try approximated genitive form : tuomikirkko, tampere -> tampere tuomiokirkko
       // exact genitive form is hard e.g. in finnish lang: turku->turun, lieto->liedon ...
       parsedText.regions.forEach(function(region) {

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -324,12 +324,11 @@ function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
  */
 function checkName(text, parsedText, hit) {
 
-  var isVenue = hit.layer === 'venue' || hit.layer === 'stop' || hit.layer === 'station';
-
   // parsedText name should take precedence if available since it's the cleaner name property
   if (check.assigned(parsedText) && check.assigned(parsedText.name)) {
     var name = parsedText.name;
-      var bestScore = checkLanguageNames(name, hit, false, isVenue);
+    var isVenue = hit.layer === 'venue' || hit.layer === 'stop' || hit.layer === 'station';
+    var bestScore = checkLanguageNames(name, hit, false, isVenue);
 
     if (parsedText.regions && isVenue) {
       // try approximated genitive form : tuomikirkko, tampere -> tampere tuomiokirkko

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -420,6 +420,7 @@ function checkAdmin(values, hit) {
 
   values.forEach(function(value) {
     var best=0, weight = 1;
+    var nvalue = normalize(value);
 
     // loop trough configured properties to find best match
     for(var key in adminWeights) {
@@ -431,9 +432,9 @@ function checkAdmin(values, hit) {
           for(var i in prop) {
             nProp.push(normalize(prop[i]));
           }
-          match = fuzzy.matchArray(normalize(value), nProp);
+          match = fuzzy.matchArray(nvalue, nProp);
         } else {
-          match = fuzzy.match(normalize(value), normalize(prop));
+          match = fuzzy.match(nvalue, normalize(prop));
         }
         if(match>best) {
           best = match;

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -1,4 +1,4 @@
-{
+g{
   "esclient": {
     "apiVersion": "2.3",
     "keepAlive": true,
@@ -101,7 +101,7 @@
       },
       "labelSchemas": {
         "FIN": {
-          "address": { "fields": [["street", "housenumber"], "neighbourhood"], "matchType": "first" },
+          "address": { "fields": [["street", "housenumber"], "neighbourhood"], "matchType": "first", "targets": ["venue", "stop", "station"] },
           "local": { "fields": ["localadmin", "locality"], "matchType": "best" }
         }
       }

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -25,7 +25,7 @@
     "indexName": "pelias",
     "version": "1.0",
     "textAnalyzer": "libpostal",
-    "sizePadding": 6,
+    "sizePadding": 10,
     "minConfidence": 0.2,
     "relativeMinConfidence": 0.4,
     "languageMatchThreshold": 0.4,

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -77,12 +77,13 @@ g{
       "sorting":"fi"
     },
     "localization" : {
-        "confidenceAdminWeights": {
+      "confidenceAdminWeights": {
         "localadmin": 1,
         "locality": 0.2,
         "neighbourhood": 0.2,
         "region": 0.2,
-        "country": 0.1
+        "country": 0.1,
+        "street": 0.2
       },
       "confidenceAddressParts": {
 	"number": {"parent":"address_parts", "field":"number", "numeric": true, "weight": 0.5},

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -34,20 +34,28 @@ if (api && api.localization) {
 }
 
 
-// original query cannot handle libpostal's scandic letter conversion ä -> ae
-// So try restoring the strings. Simple method below works for 99% of cases
+// libpostal's parsing cconverts scandic letters: ä -> a ...
+// try restoring the strings
+
+var restoreMap = { 'ä':'a', 'ö':'o', 'å':'a' };
+var restoreRegex = {};
+
+for(var c in restoreMap) {
+  restoreRegex[c] = new RegExp(c, 'gi');
+}
 
 function restoreParsed(parsed, text) {
-  var restoreMap = { 'ä':'ae', 'ö':'oe', 'å':'aa' };
+  var ntext = text;
 
-  _.forEach(restoreMap, function(xx, c) {
-    if(text.indexOf(c) !== -1 ) {
-      parsed = parsed.replace(new RegExp(xx, 'g'), c);
-    }
-  });
-  // see if restored string is part of original text
-  if(text.indexOf(parsed) !== -1) { // yeah, succeeded
-    return parsed;
+  for(var c in restoreMap) {
+    ntext = ntext.replace(restoreRegex[c], restoreMap[c]);
+  }
+
+  // see if parsed string is part of converted text
+  var index = ntext.indexOf(parsed);
+  var len = parsed.length;
+  if(index > -1 && index + len <= text.length) { // yeah, found
+    return text.substring(index, index+len);
   }
   return null;
 }

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -64,6 +64,11 @@ function addAdmin(parsedText, admin) {
 
 function assignValidLibpostalParsing(parsedText, fromLibpostal, text) {
 
+  // validate street number
+  if(check.assigned(fromLibpostal.number) && streetNumberValidator(fromLibpostal.number)) {
+    parsedText.number = fromLibpostal.number;
+  }
+
   // if 'query' part is set, libpostal has probably failed in parsing
   // NOTE!! This may change when libpostal parsing improves
   // try reqularly using libpostal parsing also when query field is set.
@@ -73,7 +78,13 @@ function assignValidLibpostalParsing(parsedText, fromLibpostal, text) {
     if(check.assigned(fromLibpostal.street)) {
       var street = restoreParsed(fromLibpostal.street, text);
       if(street) {
-        parsedText.street = street;
+        if((!parsedText.name || parsedText.name.toLowerCase()===street) && !parsedText.number) {
+          // plain parsed street is suspicious as Libpostal often maps venue name to street
+          // better to search it via name
+          parsedText.name = street;
+        } else {
+          parsedText.street = street;
+        }
       }
     }
 
@@ -107,10 +118,6 @@ function assignValidLibpostalParsing(parsedText, fromLibpostal, text) {
         }
       }
     }
-  }
-  // validate street number
-  if(check.assigned(fromLibpostal.number) && streetNumberValidator(fromLibpostal.number)) {
-    parsedText.number = fromLibpostal.number;
   }
 
   // validate postalcode


### PR DESCRIPTION
The main improvement in this pull request is that pelias api now automatically tries different combinations of the actual name and the admin / street names. The purpose is to find matches with genitive expressions:

- Tampereen tuomiokirkko / Tuomiokirkko, Tampere
- Porin kauppatori / kauppatori, Pori
- Yrjönkadun uimahalli / Uimahalli, Yrjönkatu
- Urheilupyörä, Tampere  / Suomen urheilupyörä, Tampere
etc.

Combinations are tried only in scoring stage. Actual ES search size is expanded to gather more promising components for final scoring. This seems to be a good approach as the primary search must be fast. Two stage search now extraxts 120 candidates from 4 million, and analyzes those in detail.

Second imporvement is that multi-part names 'venue, street, city' are now parsed/scored better. 

PR also includes several bug fixes for detected problems:
- Double streetnime labeling  (sv + fi) bug fixed
- Numerous libpostal parsing errors fixed and libpostal character transformation map updated

