### PR TITLE
Allow regex in sources parameter definition

### DIFF
--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -16,11 +16,11 @@ function addStandardTargetsToAliases(standard, aliases) {
  * Sources
  */
 
-// a list of all sources
-var SOURCES = ['openstreetmap', 'openaddresses', 'geonames', 'whosonfirst', 'gtfs', 'nlsfi'];
+// a list of sources with fixed names
+var SOURCES = ['openstreetmap', 'openaddresses', 'geonames', 'whosonfirst', 'nlsfi'];
 
 /*
- * A list of alternate names for sources, mostly used to save typing
+ * A list of alternate names and regular expressions for sources, mostly used to save typing
  */
 var SOURCE_ALIASES = {
   'osm': ['openstreetmap'],

--- a/sanitizer/_sources_and_layers.js
+++ b/sanitizer/_sources_and_layers.js
@@ -13,6 +13,9 @@ function sanitize( raw, clean ){
 
   if (clean.layers && clean.sources) {
     clean.sources.forEach(function(source) {
+      if (source.indexOf('gtfs') === 0) {
+        source = 'gtfs'; // map gtfs<feedid> to plain gtfs
+      }
       var layers_for_source = type_mapping.layers_by_source[source];
       clean.layers.forEach(function(layer) {
         if (_.includes(layers_for_source, layer)) {


### PR DESCRIPTION
Parameter validation relaxed to allow regular expressions.
'gtfs' alias accepts all sources which include 'gtfs' string  and passes
the source name as is forward (except for lowercase conversion).

For example, to search for hsl stops, set a parameter sources=gtfshsl