### PR TITLE
Remove pelias sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "pelias-microservice-wrapper": "1.2.0",
     "pelias-model": "5.0.1",
     "pelias-query": "9.0.0",
-    "pelias-sorting": "1.0.1",
     "pelias-text-analyzer": "1.9.1",
     "predicates": "^1.0.1",
     "retry": "^0.10.1",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -274,7 +274,7 @@ function addRoutes(app, peliasConfig) {
       postProc.confidenceScores(peliasConfig.api),
       postProc.matchLanguage(peliasConfig.api),
       postProc.interpolate(interpolationService, interpolationShouldExecute),
-      postProc.sortResponseData(require('pelias-sorting'), hasAdminOnlyResults),
+//      postProc.sortResponseData(require('pelias-sorting'), hasAdminOnlyResults),
       postProc.dedupe(),
       postProc.accuracy(),
       postProc.translate(),


### PR DESCRIPTION
A new sort module sneaked into search endpoint configuration in the latest upstream merge. Must be removed. 