### PR TITLE
Parsing fixes

### DIFF
--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -78,7 +78,13 @@ function assignValidLibpostalParsing(parsedText, fromLibpostal, text) {
       var addrIndex = parsedText.regions.indexOf(address);
       if (addrIndex > -1) {
         parsedText.regions.splice(addrIndex, 1);
-        parsedText.admin_parts = parsedText.regions.join(DELIM + ' ');
+        if (parsedText.regions.length === 0) {
+          delete parsedText.regions;
+          delete parsedText.admin_parts;
+        }
+        else {
+          parsedText.admin_parts = parsedText.regions.join(DELIM + ' ');
+        }
       }
     }
   }

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -99,8 +99,11 @@ function assignValidLibpostalParsing(parsedText, fromLibpostal, text) {
     }
   }
 
-  const city = fromLibpostal.city;
+  var city = fromLibpostal.city;
   if(city) {
+    if(parsedText.name && city === parsedText.name + ' ' + parsedText.name) {
+      city = parsedText.name;
+    }
     parsedText.city = city;
     if(parsedText.name && parsedText.name !== city) {
       addAdmin(parsedText, city);


### PR DESCRIPTION
Libpostal parses Finnish addresses of type 'city, city' wrong:
- Helsinki, Helsinki maps as Street=Helsinki, City=Helsinki. Admin regions became an empty array which lead later to zero division in scoring and no found results. Special case detected and handled correctly.
-   Small cities parse to a double city name. Example: Kouvola, Kouvola maps to city='Kouvola Kouvola'. This special case is checked and fixed. 
