### PR TITLE
Updated docker tagging logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 branches:
   only:
     - master
+    - force-build
     - /20(1[7-9]|2[0-9])[0-1][0-9][0-3][0-9]/
 
 services: docker

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -6,18 +6,27 @@
 set -e
 
 ORG=${ORG:-hsldevcom}
-DOCKER_TAG=${TRAVIS_COMMIT:-latest}
+DOCKER_TAG="latest"
 DOCKER_IMAGE=$ORG/pelias-api
-DOCKER_IMAGE_COMMIT=$DOCKER_IMAGE:$DOCKER_TAG
-DOCKER_IMAGE_LATEST=$DOCKER_IMAGE:latest
-DOCKER_IMAGE_PROD=$DOCKER_IMAGE:prod
 API=pelias-api
+
+if [ "$TRAVIS_TAG" ]; then
+  DOCKER_TAG="prod"
+elif [ "$TRAVIS_BRANCH" != "master" ]; then
+  DOCKER_TAG=$TRAVIS_BRANCH
+fi
+
+DOCKER_TAG_LONG=$DOCKER_TAG-$(date +"%Y-%m-%dT%H.%M.%S")-${TRAVIS_COMMIT:0:7}
+DOCKER_IMAGE_LATEST=$DOCKER_IMAGE:latest
+DOCKER_IMAGE_TAG=$DOCKER_IMAGE:$DOCKER_TAG
+DOCKER_IMAGE_TAG_LONG=$DOCKER_IMAGE:$DOCKER_TAG_LONG
+
 
 if [ -z $TRAVIS_TAG ]; then
     # Build image
     echo "Building pelias-api"
-    docker build --tag="$DOCKER_IMAGE_COMMIT" .
-    docker run --name $API -p 3100:8080 --rm $DOCKER_IMAGE_COMMIT &
+    docker build --tag="$DOCKER_IMAGE_TAG_LONG" .
+    docker run --name $API -p 3100:8080 --rm $DOCKER_IMAGE_TAG_LONG &
     sleep 20
     HOST=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $API)
     STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://$HOST:8080/v1)
@@ -35,15 +44,17 @@ fi
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
     docker login -u $DOCKER_USER -p $DOCKER_AUTH
     if [ "$TRAVIS_TAG" ];then
-        echo "processing release $TRAVIS_TAG"
-        docker pull $DOCKER_IMAGE_COMMIT
-        docker tag $DOCKER_IMAGE_COMMIT $DOCKER_IMAGE_PROD
-        docker push $DOCKER_IMAGE_PROD
+      echo "processing release $TRAVIS_TAG"
+      docker pull $DOCKER_IMAGE_LATEST
+      docker tag $DOCKER_IMAGE_LATEST $DOCKER_IMAGE_TAG
+      docker tag $DOCKER_IMAGE_LATEST $DOCKER_IMAGE_TAG_LONG
+      docker push $DOCKER_IMAGE_TAG
+      docker push $DOCKER_IMAGE_TAG_LONG
     else
-        echo "Pushing latest image"
-        docker push $DOCKER_IMAGE_COMMIT
-        docker tag $DOCKER_IMAGE_COMMIT $DOCKER_IMAGE_LATEST
-        docker push $DOCKER_IMAGE_LATEST
+      echo "Pushing $DOCKER_TAG image"
+      docker push $DOCKER_IMAGE_TAG_LONG
+      docker tag $DOCKER_IMAGE_TAG_LONG $DOCKER_IMAGE_TAG
+      docker push $DOCKER_IMAGE_TAG
     fi
 fi
 


### PR DESCRIPTION
The logic for pushing and pulling changed slightly. On release, the previous version used to pull image tagged with current git-commit and then tag it as production image. The new version pulls 'latest' tag and then tags it as production image.

It should not make a difference if used normally so that master builds are followed by releases. The latest and git-commit are in sync in that case.