### PR TITLE
filter bad suggestions easier if there are good ones available

### DIFF
--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -45,7 +45,7 @@
     "textAnalyzer": "libpostal",
     "sizePadding": 12,
     "minConfidence": 0.2,
-    "relativeMinConfidence": 0.4,
+    "relativeMinConfidence": 0.6,
     "languageMatchThreshold": 0.4,
     "query": {
       "search": {


### PR DESCRIPTION
relativeMinConfidence defines limit how much worse suggestions as  the best one are dropped.
Limit was quite low: with a perfect match 1, suggestions rated as 0.4 were still included.
Use 0.6 as new relative limit.