### PR TITLE
DT-3556 - better fuzzy scoring in pelias api

### DIFF
--- a/helper/fuzzyMatch.js
+++ b/helper/fuzzyMatch.js
@@ -1,77 +1,160 @@
-var fuzzy = require('fuzzy.js');
-
 var stringUtils = require('../helper/stringUtils');
 var normalize = stringUtils.normalize;
 var removeSpaces = stringUtils.removeSpaces;
 
+/* Jaro-Winkler algo returns 1.0 only when strings are identical
+   Totally different strings return 0.
+*/
 
-// fuzzy.js score range is not normalized but depends on string length as computed below
-// NOTE: recheck whenever updating fuzzy.js version!
-function getMaxScore(len) {
-  return 3*(len - 1) + 1;
+var jw  = function (s1, s2) {
+  var m = 0;
+
+  // Exit early if either are empty.
+  if ( s1.length === 0 || s2.length === 0 ) {
+    return 0;
+  }
+
+  // Exit early if they're an exact match.
+  if ( s1 === s2 ) {
+    return 1;
+  }
+
+  var range     = (Math.floor(Math.max(s1.length, s2.length) / 2)) - 1,
+      s1Matches = new Array(s1.length),
+      s2Matches = new Array(s2.length);
+
+  for ( i = 0; i < s1.length; i++ ) {
+    var low  = (i >= range) ? i - range : 0,
+        high = (i + range <= s2.length) ? (i + range) : (s2.length - 1);
+
+    for ( j = low; j <= high; j++ ) {
+      if ( s1Matches[i] !== true && s2Matches[j] !== true && s1[i] === s2[j] ) {
+        ++m;
+        s1Matches[i] = s2Matches[j] = true;
+        break;
+      }
+    }
+  }
+
+  // Exit early if no matches were found.
+  if ( m === 0 ) {
+    return 0;
+  }
+
+  // Count the transpositions.
+  var k = n_trans = 0;
+
+  for ( i = 0; i < s1.length; i++ ) {
+    if ( s1Matches[i] === true ) {
+      for ( j = k; j < s2.length; j++ ) {
+        if ( s2Matches[j] === true ) {
+          k = j + 1;
+          break;
+        }
+      }
+
+      if ( s1[i] !== s2[j] ) {
+        ++n_trans;
+      }
+    }
+  }
+
+  var weight = (m / s1.length + m / s2.length + (m - (n_trans / 2)) / m) / 3,
+      l = 0,
+      p = 0.1;
+
+  if ( weight > 0.7 ) {
+    while ( s1[l] === s2[l] && l < 4 ) {
+      ++l;
+    }
+
+    weight = weight + l * p * (1 - weight);
+  }
+
+  return weight;
 }
 
 
-/* returns 1.0 only when strings are identical
-   Totally different strings return 0.
-   Original fuzzyjs prefers strings with a similar start.
-   Here that limitation is cured by evaluating score from
-   direct substring match. For example, 'citymarket' is not a bad
-   match with 'k-citymarket' or even with 'turtolan k-citymarket'.
-   Hopefully a proper fuzzy match library will be found.
-   Meanwhile, we patch the worst faults ourselves.
-*/
+var cachedPermutation = {}; // one item cache
+
+// Generating permutation using heap algorithm
+function heapPermutation(a, size, n, result)
+{
+  // if size becomes 1 then collect the obtained permutation
+  if (size === 1) {
+    result.push(a.join(''));
+  } else for (let i = 0; i < size; i++) {
+    heapPermutation(a, size - 1, n, result);
+
+    // if size is odd, swap 0th i.e (first) and (size-1)th i.e (last) element
+    if (size % 2 == 1) {
+      let temp = a[0];
+      a[0] = a[size - 1];
+      a[size - 1] = temp;
+    }
+
+    // If size is even, swap ith and (size-1)th i.e last element
+    else {
+      let temp = a[i];
+      a[i] = a[size - 1];
+      a[size - 1] = temp;
+    }
+  }
+}
 
 function _fuzzyMatch(text1, text2) {
   // at the lowest match level, consider spaces insignificant. east west pub = eastwestpub
   text1 = removeSpaces(text1);
   text2 = removeSpaces(text2);
 
-  var len1 = text1.length;
-  var len2 = text2.length;
-
-  var fscore = fuzzy(text1, text2).score;
-  var score = fscore/getMaxScore(len1); // normalized 0 .. 1 score
-  var score2; // alternative scoring by direct substring match
-
-  if (len1>=len2) {
-    if(text1.indexOf(text2)!==-1) {
-      score2 = len2/len1;
-    }
-  } else {
-    // do not punish from missing tail part too much ...
-    var minScore = fscore/getMaxScore(len1 + 1);
-    var key = len1/len2;
-    // Interpolate final score. The more missing chars, the lower the score
-    score = key*score + (1-key)*minScore;
-
-    var subIndex = text2.indexOf(text1);
-    if(subIndex !== -1) {
-      score2 = len1/(len2 + subIndex); // favor match at start
-    }
-  }
-  if (score2 && score2>score) {
-    return score2;
-  }
-
-  return score;
+  return jw(text1, text2);
 }
 
-// matching which takes word order into account
+// Matching which considers word ordering insignificant.
+// Citymarket Turtola is nearly perfect match with Turtolan Citymarket.
 function fuzzyMatch(text1, text2) {
   text1 = normalize(text1);
   text2 = normalize(text2);
 
   // straight match as a whole string
   var score = _fuzzyMatch(text1, text2);
+  if(score === 1) {
+    return score;
+  }
 
   // consider change of order e.g. Citymarket turtola | Turtolan citymarket
   // In normal text, change of order can be very significant. With addresses,
   // order does not matter that much.
   var words1 = text1.split(' ');
   var words2 = text2.split(' ');
+  if(words1.length === 1 && words2.length === 1) {
+    return score;
+  }
 
-  if(words1.length>1 || words2.length>1) {
+  if(words1.length<4 && words2.length<4) { // must limit the length, long permutations are too slow
+    var perm1;
+    var perm2 = [];
+    if (cachedPermutation.key === text1) {
+      // search text permutation can be cached
+      perm1 = cachedPermutation.result;
+    } else {
+      perm1 = [];
+      // generate all possible orderings of word sequence
+      heapPermutation(words1, words1.length, words1.length, perm1);
+      cachedPermutation.key = text1;
+      cachedPermutation.result = perm1;
+    }
+    heapPermutation(words2, words2.length, words2.length, perm2);
+
+    perm1.forEach(function(p1) {
+      perm2.forEach(function(p2) {
+	var wscore = _fuzzyMatch(p1, p2);
+	if (wscore>score) {
+          score=wscore;
+	}
+      });
+    });
+  } else { // use simpler comparison for long sentences, complexity just O(n*m)
     if(words1.length>words2.length) {
       var temp = words1;
       words1 = words2;
@@ -79,10 +162,15 @@ function fuzzyMatch(text1, text2) {
     }
     var wordScore=0;
     var weightSum=0;
-    var matched=[];
+    var matched={};
+    var foo = '';
     words1.forEach(function(word1) {
+      // find best matching yet unused word
       var bestScore=0, bestIndex;
       for(var wi in words2) {
+	if (matched[wi]) {
+	  continue;
+	}
         var wscore = _fuzzyMatch(word1, words2[wi]);
         if (wscore>bestScore) {
           bestScore=wscore;
@@ -93,8 +181,8 @@ function fuzzyMatch(text1, text2) {
       wordScore += l*bestScore; // weight by word len
       weightSum += l;
       matched[bestIndex]=true;
+      foo += words2[bestIndex];
     });
-
     // extra words just accumulate weight, not score
     for (var wi2 in words2) {
       if (!matched[wi2]) {
@@ -121,6 +209,4 @@ function fuzzyMatchArray(text, array) {
   return maxMatch;
 }
 
-module.exports = { match: fuzzyMatch,
-                   matchArray: fuzzyMatchArray
-                 };
+module.exports = { match: fuzzyMatch, matchArray: fuzzyMatchArray };

--- a/helper/fuzzyMatch.js
+++ b/helper/fuzzyMatch.js
@@ -118,7 +118,7 @@ function _fuzzyMatch(text1, text2) {
      Koulumäki is rated better which is totally counter intuitive
   */
   var score = jw(text1, text2);
-  if(false && text2.indexOf(text1) === 0) {
+  if(text2.indexOf(text1) === 0) {
     var key = text1.length/text2.length;
     score = key + (1-key)*score; // interpolate towards max score 1.0
   }

--- a/helper/fuzzyMatch.js
+++ b/helper/fuzzyMatch.js
@@ -19,15 +19,17 @@ var jw  = function (s1, s2) {
     return 1;
   }
 
-  var range     = (Math.floor(Math.max(s1.length, s2.length) / 2)) - 1,
+  var range = (Math.floor(Math.max(s1.length, s2.length) / 2)) - 1,
       s1Matches = new Array(s1.length),
       s2Matches = new Array(s2.length);
 
-  for ( i = 0; i < s1.length; i++ ) {
-    var low  = (i >= range) ? i - range : 0,
+  var i, j;
+
+  for (i = 0; i < s1.length; i++) {
+    let low  = (i >= range) ? i - range : 0,
         high = (i + range <= s2.length) ? (i + range) : (s2.length - 1);
 
-    for ( j = low; j <= high; j++ ) {
+    for (j = low; j <= high; j++ ) {
       if ( s1Matches[i] !== true && s2Matches[j] !== true && s1[i] === s2[j] ) {
         ++m;
         s1Matches[i] = s2Matches[j] = true;
@@ -42,11 +44,12 @@ var jw  = function (s1, s2) {
   }
 
   // Count the transpositions.
-  var k = n_trans = 0;
+  let k = 0;
+  let n_trans = 0;
 
-  for ( i = 0; i < s1.length; i++ ) {
+  for (i = 0; i < s1.length; i++ ) {
     if ( s1Matches[i] === true ) {
-      for ( j = k; j < s2.length; j++ ) {
+      for (j = k; j < s2.length; j++ ) {
         if ( s2Matches[j] === true ) {
           k = j + 1;
           break;
@@ -59,7 +62,7 @@ var jw  = function (s1, s2) {
     }
   }
 
-  var weight = (m / s1.length + m / s2.length + (m - (n_trans / 2)) / m) / 3,
+  let weight = (m / s1.length + m / s2.length + (m - (n_trans / 2)) / m) / 3,
       l = 0,
       p = 0.1;
 
@@ -72,8 +75,7 @@ var jw  = function (s1, s2) {
   }
 
   return weight;
-}
-
+};
 
 var cachedPermutation = {}; // one item cache
 
@@ -87,7 +89,7 @@ function heapPermutation(a, size, n, result)
     heapPermutation(a, size - 1, n, result);
 
     // if size is odd, swap 0th i.e (first) and (size-1)th i.e (last) element
-    if (size % 2 == 1) {
+    if (size % 2 === 1) {
       let temp = a[0];
       a[0] = a[size - 1];
       a[size - 1] = temp;
@@ -131,7 +133,7 @@ function fuzzyMatch(text1, text2) {
     return score;
   }
 
-  if(words1.length<4 && words2.length<4) { // must limit the length, long permutations are too slow
+  if(words1.length<5 && words2.length<5) { // must limit the length, long permutations are too slow
     var perm1;
     var perm2 = [];
     if (cachedPermutation.key === text1) {
@@ -163,7 +165,6 @@ function fuzzyMatch(text1, text2) {
     var wordScore=0;
     var weightSum=0;
     var matched={};
-    var foo = '';
     words1.forEach(function(word1) {
       // find best matching yet unused word
       var bestScore=0, bestIndex;
@@ -181,12 +182,11 @@ function fuzzyMatch(text1, text2) {
       wordScore += l*bestScore; // weight by word len
       weightSum += l;
       matched[bestIndex]=true;
-      foo += words2[bestIndex];
     });
     // extra words just accumulate weight, not score
     for (var wi2 in words2) {
       if (!matched[wi2]) {
-        weightSum += words2[wi2].length;
+        weightSum ++;
       }
     }
     wordScore /= weightSum;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "stats-lite": "^2.0.4",
     "pelias-text-analyzer": "github:hsldevcom/pelias-text-analyzer",
     "through2": "^3.0.0",
-    "fuzzy.js": "^0.1.0",
     "point-in-polygon": "1.0.1"
   },
   "devDependencies": {

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -43,7 +43,7 @@
       }
     },
     "textAnalyzer": "libpostal",
-    "sizePadding": 12,
+    "sizePadding": 14,
     "minConfidence": 0.2,
     "relativeMinConfidence": 0.6,
     "languageMatchThreshold": 0.4,

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -104,7 +104,7 @@
         "street": 0.2
       },
       "confidenceAddressParts": {
-        "number": {"parent":"address_parts", "field":"number", "numeric": true, "weight": 0.5},
+        "number": {"parent":"address_parts", "field":"number", "numeric": true, "weight": 0.2},
         "street": {"parent":"address_parts", "field":"street", "numeric": false, "weight": 2},
         "postalcode": {"parent":"address_parts", "field":"zip", "numeric": false, "weight": 1}
       },


### PR DESCRIPTION
- Fuzzy matching algo switched from an open source npm library to a better Jaro-Winkler algorithm
- Jaro-Winkler favors match at start, but also reduces the score quite a bit if search term misses long tail part. In autocomplete type search, this is often the case.  Tail miss penalty is compensated by  increasing the score if stings match perfectly at start
- Jaro winkler does not work that well if search string and search item have similar words in different order. This is compensated by permutating the word orders and using the best permutated score. Thanks to this, 'Rovaniemen rautatieasema' matches very well 'Rautatieasema Rovaniemi'.
- Count of preliminary search results collected from elastic is increased slightly (12 ->14 * count of requested results). 

New search is about 20 % slower than previous version.