### PR TITLE
Better fuzzy search

### DIFF
--- a/controller/predicates/hasGoodMatch.js
+++ b/controller/predicates/hasGoodMatch.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+
+// simple and quick logic to decide if nearly perfect match
+// was already found, and other (fuzzy etc) queries are not needed
+
+module.exports = (request, response) => {
+
+  var ptext = _.get(request, ['clean', 'parsed_text', 'name'], {});
+  var text = ptext ||  _.get(request, ['clean', 'text']);
+  var match = _.get(response, ['data', 0, 'name', 'default']);
+
+  if (Array.isArray(match)) {
+    match = match[0];
+  }
+  if (!text || !match) {
+    return true;
+  }
+  text = text.toLowerCase();
+  match = match.toLowerCase();
+
+  return (match.indexOf(text) === 0);
+};

--- a/controller/search.js
+++ b/controller/search.js
@@ -50,7 +50,7 @@ function setup( apiConfig, esclient, query, should_execute ){
       body: renderedQuery.body
     };
 
-    logger.debug( '[ES req]', JSON.stringify(cmd) );
+    logger.info( '[ES req]', JSON.stringify(cmd) );
 
     operation.attempt((currentAttempt) => {
       const initialTime = debugLog.beginTimer(req, `Attempt ${currentAttempt}`);

--- a/controller/search.js
+++ b/controller/search.js
@@ -93,7 +93,11 @@ function setup( apiConfig, esclient, query, should_execute ){
         }
         // set response data
         else {
-          res.data = docs;
+	  if (res.data && docs) {
+	    res.data = res.data.concat(docs);
+	  } else {
+            res.data = docs;
+	  }
           res.meta = meta || {};
           // store the query_type for subsequent middleware
           res.meta.query_type = renderedQuery.type;

--- a/helper/fuzzyMatch.js
+++ b/helper/fuzzyMatch.js
@@ -202,7 +202,7 @@ function fuzzyMatch(text1, text2) {
     }
     wordScore /= weightSum;
   }
-  wordScore *= 0.99; // add very small penalty from wrong word order
+  wordScore *= 0.999; // add very small penalty from wrong word order
   if(wordScore>score) {
     return wordScore;
   }

--- a/helper/fuzzyMatch.js
+++ b/helper/fuzzyMatch.js
@@ -85,21 +85,20 @@ function heapPermutation(a, size, n, result)
   // if size becomes 1 then collect the obtained permutation
   if (size === 1) {
     result.push(a.join(''));
-  } else for (let i = 0; i < size; i++) {
-    heapPermutation(a, size - 1, n, result);
+  } else {
+    for (let i = 0; i < size; i++) {
+      heapPermutation(a, size - 1, n, result);
 
-    // if size is odd, swap 0th i.e (first) and (size-1)th i.e (last) element
-    if (size % 2 === 1) {
-      let temp = a[0];
-      a[0] = a[size - 1];
-      a[size - 1] = temp;
-    }
-
-    // If size is even, swap ith and (size-1)th i.e last element
-    else {
-      let temp = a[i];
-      a[i] = a[size - 1];
-      a[size - 1] = temp;
+      // if size is odd, swap 0th i.e (first) and (size-1)th i.e (last) element
+      if (size % 2 === 1) {
+        let temp = a[0];
+        a[0] = a[size - 1];
+        a[size - 1] = temp;
+      } else { // If size is even, swap ith and (size-1)th i.e last element
+        let temp = a[i];
+        a[i] = a[size - 1];
+        a[size - 1] = temp;
+      }
     }
   }
 }
@@ -145,7 +144,7 @@ function fuzzyMatch(text1, text2) {
   if(words1.length === 1 && words2.length === 1) {
     return score;
   }
-
+  var wordScore=0;
   if(words1.length<4 && words2.length<4) { // must limit the length, long permutations are too slow
     var perm1;
     var perm2 = [];
@@ -163,10 +162,10 @@ function fuzzyMatch(text1, text2) {
 
     perm1.forEach(function(p1) {
       perm2.forEach(function(p2) {
-	var wscore = _fuzzyMatch(p1, p2);
-	if (wscore>score) {
-          score=wscore;
-	}
+        var wscore = _fuzzyMatch(p1, p2);
+        if (wscore>wordScore) {
+          wordScore=wscore;
+        }
       });
     });
   } else { // use simpler comparison for long sentences, complexity just O(n*m)
@@ -175,16 +174,15 @@ function fuzzyMatch(text1, text2) {
       words1 = words2;
       words2 = temp;
     }
-    var wordScore=0;
     var weightSum=0;
     var matched={};
     words1.forEach(function(word1) {
       // find best matching yet unused word
       var bestScore=0, bestIndex;
       for(var wi in words2) {
-	if (matched[wi]) {
-	  continue;
-	}
+        if (matched[wi]) {
+          continue;
+        }
         var wscore = _fuzzyMatch(word1, words2[wi]);
         if (wscore>bestScore) {
           bestScore=wscore;
@@ -203,9 +201,10 @@ function fuzzyMatch(text1, text2) {
       }
     }
     wordScore /= weightSum;
-    if(wordScore>score) {
-      return wordScore;
-    }
+  }
+  wordScore *= 0.99; // add very small penalty from wrong word order
+  if(wordScore>score) {
+    return wordScore;
   }
   return score;
 }

--- a/helper/placeTypes.js
+++ b/helper/placeTypes.js
@@ -1,17 +1,7 @@
 module.exports = [
-  'ocean',
-  'marinearea',
-  'continent',
-  'empire',
-  'country',
-  'dependency',
-  'macroregion',
   'region',
-  'macrocounty',
-  'county',
   'localadmin',
   'locality',
-  'borough',
   'neighbourhood',
   'postalcode'
 ];

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -218,28 +218,13 @@ function computeConfidenceScore(req, hit) {
   }
 
   // score admin areas such as city or neigbourhood
-  if(adminWeights) {
-    var adminConfidence;
-
-    if(parsedText && parsedText.regions) {
-      adminConfidence = checkAdmin(parsedText.regions, hit);
-
-      // Keep admin scoring proportion constant 50% regardless of the
-      // count of finer score factors. Score is max 0.5 if city is all wrong
-      hit.confidence += weightSum*adminConfidence;
-      weightSum *= 2;
-    } else if(hit.confidence<1 && req.clean.text && countWords(req.clean.text)>1) {
-
-      // Text could not be parsed, and does not match any document perfectly.
-      // There is a chance that text contains admin info like small city without
-      // comma separation (libpostal misses those), or name is formatted loosely
-      // 'tampereen keskustori'. So check raw text against admin areas
-      adminConfidence = checkAdmin(req.clean.text, hit);
-      hit.confidence += (1 - hit.confidence)*adminConfidence; // leftover from name match
-    }
-    if(adminConfidence) {
-      logger.debug('admin confidence', adminConfidence);
-    }
+  if(adminWeights && parsedText && parsedText.regions) {
+    var adminConfidence = checkAdmin(parsedText.regions, hit);
+    logger.debug('admin confidence', adminConfidence);
+    // Keep admin scoring proportion constant 50% regardless of the
+    // count of finer score factors. Score is max 0.5 if city is all wrong
+    hit.confidence += weightSum*adminConfidence;
+    weightSum *= 2;
   }
 
   if(weightSum>0) {
@@ -263,14 +248,14 @@ function computeConfidenceScore(req, hit) {
  * @returns {bool}
  */
 
-function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
+function checkLanguageNames(text, doc, stripNumbers, genitiveDoc, genitiveText) {
   var bestScore = 0;
   var bestName;
   var names = doc.name;
 
-  var checkNewBest = function(name) {
-    var score = fuzzy.match(text, name);
-    logger.debug('#', text, '|', name, score);
+  var checkNewBest = function(_text, name) {
+    var score = fuzzy.match(_text, name);
+    logger.debug('#', _text, '|', name, score);
     if (score >= bestScore ) {
       bestScore = score;
       bestName = name;
@@ -278,16 +263,16 @@ function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
     return score;
   };
 
-  var checkAdminName = function(admin, name) {
+  var checkAdminName = function(_text, admin, name) {
     admin = normalize(admin);
     if(admin && name.indexOf(admin) === -1) {
-      checkNewBest(admin + ' ' + name);
+      checkNewBest(_text, admin + ' ' + name);
     }
   };
 
-  var checkAdminNames = function(admins, name) {
+  var checkAdminNames = function(_text, admins, name) {
     admins.forEach(function(admin) {
-      checkAdminName(admin, name);
+      checkAdminName(_text, admin, name);
     });
   };
 
@@ -298,22 +283,27 @@ function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
       if(stripNumbers) {
         name = removeNumbers(name);
       }
-      var score = checkNewBest(name);
+      var score = checkNewBest(text, name);
 
-      if (tryGenitive && score > genitiveThreshold && // don't prefix unless base match is OK
-          text.length > 2 + name.length ) { // Shortest admin prefix is 'ii '
+      if (score > genitiveThreshold && (genitiveDoc || genitiveText)) { // don't prefix unless base match is OK
         // prefix with parent admins to catch cases like 'kontulan r-kioski'
         var parent = doc.parent || {};
         for(var key in adminWeights) {
           var admins = parent[key];
-          if (Array.isArray(admins)) {
-            checkAdminNames(admins, name);
-          } else {
-            checkAdminName(admins, name);
+          var check = Array.isArray(admins) ? checkAdminNames : checkAdminName;
+          if(genitiveDoc && text.length > 2 + name.length) { // Shortest admin prefix is 'ii '
+            check(text, admins, name);
+            if (doc.street) { // try also street: 'helsinginkadun r-kioski'
+              checkAdminName(text, doc.street, name);
+            }
+          }
+          if (genitiveText && name.length > 2 + text.length) {
+            check(name, admins, text);
+            if (doc.street) {
+              checkAdminName(name, doc.street, text);
+            }
           }
         }
-        // try also street: 'helsinginkadun r-kioski'
-        checkAdminName(doc.street, name);
       }
     }
   };
@@ -348,16 +338,18 @@ function checkName(text, parsedText, hit) {
   // parsedText name should take precedence if available since it's the cleaner name property
   if (check.assigned(parsedText) && (check.assigned(parsedText.name) || check.assigned(parsedText.query))) {
     var name = parsedText.name || parsedText.query;
-    var isVenue = hit.layer === 'venue' || hit.layer === 'stop' || hit.layer === 'station' || hit.layer === 'bikestation';
-    var bestScore = checkLanguageNames(name, hit, false, isVenue);
+    var docIsVenue = hit.layer === 'venue' || hit.layer === 'stop' || hit.layer === 'station' || hit.layer === 'bikestation';
+    var searchIsVenue = !parsedText.street;
+    var bestScore = checkLanguageNames(name, hit, false, docIsVenue, searchIsVenue);
 
-    if (parsedText.regions && isVenue && bestScore > genitiveThreshold) {
+    if (parsedText.regions && docIsVenue && bestScore > genitiveThreshold) {
       // try approximated genitive form : tuomikirkko, tampere -> tampere tuomiokirkko
       // exact genitive form is hard e.g. in finnish lang: turku->turun, lieto->liedon ...
       parsedText.regions.forEach(function(region) {
         region = removeNumbers(region);
         if( name.indexOf(region) === -1 ) { // not already included
-          var score = checkLanguageNames(region + ' ' + name, hit);
+          // try adding genitive just at doc side, query text already has it
+          var score = checkLanguageNames(region + ' ' + name, hit, false, true, false);
           if (score > bestScore) {
             bestScore = score;
           }
@@ -368,7 +360,7 @@ function checkName(text, parsedText, hit) {
   }
 
   // if no parsedText check the full unparsed text value
-  return(checkLanguageNames(text, hit, false, true));
+  return(checkLanguageNames(text, hit, false, true, true));
 }
 
 
@@ -441,7 +433,7 @@ function checkAddressPart(text, hit, key) {
   // special case: proper version can be stored in the name
   // we need this because street name currently stores only one language
   if(key==='street' && hit.name) {
-      var _score = checkLanguageNames(text[key], hit, true, false);
+    var _score = checkLanguageNames(text[key], hit, true, false, false);
     if(_score>score) {
       score = _score;
     }

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -14,7 +14,7 @@ var removeNumbers = stringUtils.removeNumbers;
 var languages = ['default'];
 var adminWeights;
 var minConfidence=0, relativeMinConfidence;
-var genitiveThreshold = 0.4;
+var genitiveThreshold = 0.8;
 
 // default configuration for address confidence check
 var confidenceAddressParts = {
@@ -298,7 +298,7 @@ function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
               checkAdminName(text, doc.street, name);
             }
           }
-          if (genitive && nameLen > 2 + textLen) {
+          if (nameLen > 2 + textLen) {
             check(name, admins, text);
             if (doc.street) {
               checkAdminName(name, doc.street, text);

--- a/middleware/confidenceScoreDT.js
+++ b/middleware/confidenceScoreDT.js
@@ -232,7 +232,7 @@ function computeConfidenceScore(req, hit) {
   }
 
   // TODO: look at categories
-  logger.debug('### confidence', hit.confidence);
+  logger.info('### confidence', hit.confidence);
 
   return hit;
 }
@@ -319,7 +319,7 @@ function checkLanguageNames(text, doc, stripNumbers, tryGenitive) {
     }
     checkLanguageNameArray(nameArr);
   }
-  logger.debug('name confidence', bestScore, text, bestName);
+  logger.info('name confidence', bestScore, text, bestName);
 
   return bestScore;
 }
@@ -425,7 +425,7 @@ function checkAddressPart(text, hit, key) {
       score = _score;
     }
   }
-  logger.debug('address confidence for ' + key, score);
+  logger.info('address confidence for ' + key, score);
 
   return score;
 }

--- a/middleware/matchLanguage.js
+++ b/middleware/matchLanguage.js
@@ -20,7 +20,7 @@ var logger = require('pelias-logger').get('api');
 var removeNumbers = require('../helper/stringUtils').removeNumbers;
 var languages = ['default'];
 var languageMap = {};
-var languageMatchThreshold = 0.7;
+var languageMatchThreshold = 0.9;
 
 function setup(peliasConfig) {
   peliasConfig = peliasConfig || require('pelias-config').generate().api;

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -46,7 +46,7 @@
     "sizePadding": 14,
     "minConfidence": 0.8,
     "relativeMinConfidence": 0.8,
-    "languageMatchThreshold": 0.8,
+    "languageMatchThreshold": 0.9,
     "query": {
       "search": {
         "disableFallback": true,

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -43,7 +43,7 @@
       }
     },
     "textAnalyzer": "libpostal",
-    "sizePadding": 14,
+    "sizePadding": 7,
     "minConfidence": 0.8,
     "relativeMinConfidence": 0.8,
     "languageMatchThreshold": 0.9,

--- a/query/fuzzy.js
+++ b/query/fuzzy.js
@@ -1,0 +1,196 @@
+const _ = require('lodash');
+const peliasQuery = require('pelias-query');
+const defaults = require('./search_defaults');
+const textParser = require('./text_parser');
+
+var USE_FALLBACK_QUERY = true;
+var api = require('pelias-config').generate().api;
+if (api && api.query && api.query.search && api.query.search.disableFallback) {
+  USE_FALLBACK_QUERY = false;
+}
+
+//------------------------------
+// general-purpose search query
+//------------------------------
+var fallbackQuery = new peliasQuery.layout.FallbackQuery();
+
+// scoring boost
+fallbackQuery.score( peliasQuery.view.focus_only_function( ) );
+fallbackQuery.score( peliasQuery.view.popularity_only_function );
+fallbackQuery.score( peliasQuery.view.population_only_function );
+// --------------------------------
+
+// non-scoring hard filters
+fallbackQuery.filter( peliasQuery.view.boundary_country );
+fallbackQuery.filter( peliasQuery.view.boundary_circle );
+fallbackQuery.filter( peliasQuery.view.boundary_rect );
+fallbackQuery.filter( peliasQuery.view.boundary_polygon );
+fallbackQuery.filter( peliasQuery.view.sources );
+fallbackQuery.filter( peliasQuery.view.layers );
+fallbackQuery.filter( peliasQuery.view.categories );
+fallbackQuery.filter( peliasQuery.view.boundary_gid );
+// --------------------------------
+
+/**
+  map request variables to query variables for all inputs
+  provided by this HTTP request.
+**/
+function generateQuery( clean ){
+
+  const vs = new peliasQuery.Vars( defaults );
+
+
+  // input text
+  vs.var( 'input:name', clean.text );
+
+  vs.var( 'multi_match:fuzziness', 'AUTO');
+
+  // sources
+  if( _.isArray(clean.sources) && !_.isEmpty(clean.sources) ) {
+    vs.var( 'sources', clean.sources);
+  }
+
+  // layers
+  if( _.isArray(clean.layers) && !_.isEmpty(clean.layers) ) {
+    vs.var('layers', clean.layers);
+  }
+
+  // categories
+  if (clean.categories && !_.isEmpty(clean.categories)) {
+    vs.var('input:categories', clean.categories);
+  }
+
+  // size
+  if( clean.querySize ) {
+    vs.var( 'size', clean.querySize );
+  }
+
+  // focus point
+  if( _.isFinite(clean['focus.point.lat']) &&
+      _.isFinite(clean['focus.point.lon']) ){
+    vs.set({
+      'focus:point:lat': clean['focus.point.lat'],
+      'focus:point:lon': clean['focus.point.lon']
+    });
+  }
+
+  // boundary rect
+  if( _.isFinite(clean['boundary.rect.min_lat']) &&
+      _.isFinite(clean['boundary.rect.max_lat']) &&
+      _.isFinite(clean['boundary.rect.min_lon']) &&
+      _.isFinite(clean['boundary.rect.max_lon']) ){
+    vs.set({
+      'boundary:rect:top': clean['boundary.rect.max_lat'],
+      'boundary:rect:right': clean['boundary.rect.max_lon'],
+      'boundary:rect:bottom': clean['boundary.rect.min_lat'],
+      'boundary:rect:left': clean['boundary.rect.min_lon']
+    });
+  }
+
+  // boundary rect
+  if( clean['boundary.polygon']) {
+    vs.var('boundary:polygon', clean['boundary.polygon']);
+  }
+
+  // boundary circle
+  // @todo: change these to the correct request variable names
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
+    vs.set({
+      'boundary:circle:lat': clean['boundary.circle.lat'],
+      'boundary:circle:lon': clean['boundary.circle.lon']
+    });
+
+    if( _.isFinite(clean['boundary.circle.radius']) ){
+      vs.set({
+        'boundary:circle:radius': Math.round( clean['boundary.circle.radius'] ) + 'km'
+      });
+    }
+  }
+
+  // boundary country
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
+    vs.set({
+      'boundary:country': clean['boundary.country'].join(' ')
+    });
+  }
+
+  // boundary gid
+  if ( _.isString(clean['boundary.gid']) ){
+    vs.set({
+      'boundary:gid': clean['boundary.gid']
+    });
+  }
+
+  // run the address parser
+  if( clean.parsed_text ){
+    textParser( clean.parsed_text, vs );
+  }
+
+  var q = getQuery(vs);
+
+  //console.log(JSON.stringify(q, null, 2));
+
+  return q;
+}
+
+function getQuery(vs) {
+  if (USE_FALLBACK_QUERY && (hasStreet(vs) || isPostalCodeOnly(vs))) {
+    return {
+      type: 'search_fallback',
+      body: fallbackQuery.render(vs)
+    };
+  }
+
+  // returning undefined is a signal to a later step that a fallback parser
+  // query should be queried for
+  return undefined;
+
+}
+
+function determineQueryType(vs) {
+  if (vs.isset('input:housenumber') && vs.isset('input:street')) {
+    return 'address';
+  }
+  else if (vs.isset('input:street')) {
+    return 'street';
+  }
+  else if (vs.isset('input:query')) {
+    return 'venue';
+  }
+  else if (['neighbourhood', 'borough', 'postcode', 'county', 'region','country'].some(
+    layer => vs.isset(`input:${layer}`)
+  )) {
+    return 'admin';
+  }
+  return 'other';
+}
+
+function hasStreet(vs) {
+  return vs.isset('input:street');
+}
+
+function isPostalCodeOnly(vs) {
+  var isSet = layer => vs.isset(`input:${layer}`);
+
+  var allowedFields = ['postcode'];
+  var disallowedFields = ['query', 'category', 'housenumber', 'street',
+    'neighbourhood', 'borough', 'county', 'region', 'country'];
+
+  return allowedFields.every(isSet) &&
+    !disallowedFields.some(isSet);
+}
+
+
+function isPostalCodeWithAdmin(vs) {
+    var isSet = (layer) => {
+        return vs.isset(`input:${layer}`);
+    };
+
+    var disallowedFields = ['query', 'category', 'housenumber', 'street'];
+
+    return isSet('postcode') &&
+      !disallowedFields.some(isSet);
+}
+
+module.exports = generateQuery;

--- a/query/fuzzy.js
+++ b/query/fuzzy.js
@@ -17,9 +17,6 @@ if (config && config.query && config.query.search && config.query.search.default
 //------------------------------
 var query = new peliasQuery.layout.FilteredBooleanQuery();
 
-// mandatory matches
-// query.score( peliasQuery.view.ngrams, 'must' );
-
 // scoring boost
 query.score( peliasQuery.view.phrase );
 query.score( peliasQuery.view.focus( peliasQuery.view.phrase ) );
@@ -56,7 +53,6 @@ function generateQuery( clean ){
 
   // input text
   vs.var( 'input:name', clean.text );
-  vs.var( 'match_phrase:main:input', clean.text );
   vs.var('multi_match:fuzziness', 'AUTO');
 
   // sources
@@ -74,8 +70,9 @@ function generateQuery( clean ){
     vs.var('input:categories', clean.categories);
   }
 
-  // size
+
   if( clean.querySize ) {
+    // use smaller fuzzy query to improve speed
     vs.var( 'size', Math.floor(0.5 + clean.querySize/2) );
   } else {
     vs.var( 'size', 5 );

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -16,7 +16,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:rect:type': 'indexed',
 
-  'ngram:analyzer': 'peliasQueryFullToken',
+  'ngram:analyzer': 'peliasIndexOneEdgeGram',
   'ngram:field': 'name.default',
   'ngram:boost': 1,
 

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -58,30 +58,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   // generic multi_match cutoff_frequency
   'multi_match:cutoff_frequency': 0.01,
 
-  'admin:country_a:analyzer': 'standard',
-  'admin:country_a:field': 'parent.country_a',
-  'admin:country_a:boost': 1,
-  'admin:country_a:cutoff_frequency': 0.01,
-
-  'admin:country:analyzer': 'peliasAdmin',
-  'admin:country:field': 'parent.country',
-  'admin:country:boost': 1,
-  'admin:country:cutoff_frequency': 0.01,
-
   'admin:region:analyzer': 'peliasAdmin',
   'admin:region:field': 'parent.region',
   'admin:region:boost': 1,
   'admin:region:cutoff_frequency': 0.01,
-
-  'admin:region_a:analyzer': 'peliasAdmin',
-  'admin:region_a:field': 'parent.region_a',
-  'admin:region_a:boost': 1,
-  'admin:region_a:cutoff_frequency': 0.01,
-
-  'admin:county:analyzer': 'peliasAdmin',
-  'admin:county:field': 'parent.county',
-  'admin:county:boost': 1,
-  'admin:county:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin',
@@ -93,25 +73,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:locality:boost': 1,
   'admin:locality:cutoff_frequency': 0.01,
 
-  'admin:borough:analyzer': 'peliasAdmin',
-  'admin:borough:field': 'parent.borough',
-  'admin:borough:boost': 1,
-  'admin:borough:cutoff_frequency': 0.01,
-
   'admin:neighbourhood:analyzer': 'peliasAdmin',
   'admin:neighbourhood:field': 'parent.neighbourhood',
   'admin:neighbourhood:boost': 1,
   'admin:neighbourhood:cutoff_frequency': 0.01,
-
-  'popularity:field': 'popularity',
-  'popularity:modifier': 'log1p',
-  'popularity:max_boost': 20,
-  'popularity:weight': 1,
-
-  'population:field': 'population',
-  'population:modifier': 'log1p',
-  'population:max_boost': 20,
-  'population:weight': 2,
 
   // used by fallback queries
   // @todo: it is also possible to specify layer boosting

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -4,13 +4,8 @@ var defaults = require('./search_defaults');
 const textParser = require('./text_parser_pelias');
 const config = require('pelias-config').generate().api;
 
-var placeTypes = require('../helper/placeTypes');
+var adminFields = require('../helper/placeTypes');
 var views = { custom_boosts: require('./view/boost_sources_and_layers') };
-
-// region_a is also an admin field which can be identified by
-// the pelias_parser. this functionality was inherited from the
-// previous parser we used prior to the creation of pelias_parser.
-var adminFields = placeTypes.concat(['region_a']);
 
 if (config && config.query && config.query.search && config.query.search.defaults) {
   // merge external defaults if available
@@ -61,7 +56,6 @@ function generateQuery( clean ){
 
   // input text
   vs.var( 'input:name', clean.text );
-  vs.var( 'match_phrase:main:input', clean.text );
 
   // sources
   if( _.isArray(clean.sources) && !_.isEmpty(clean.sources) ) {

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -44,7 +44,8 @@ var queries = {
   structured_geocoding: require('../query/structured_geocoding'),
   reverse: require('../query/reverse'),
   autocomplete: require('../query/autocomplete'),
-  address_using_ids: require('../query/address_search_using_ids')
+  address_using_ids: require('../query/address_search_using_ids'),
+  fuzzy: require('../query/fuzzy')
 };
 
 /** ----------------------- controllers ----------------------- **/
@@ -295,6 +296,7 @@ function addRoutes(app, peliasConfig) {
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderIdsLookupShouldExecute),
       sanitizers.defer_to_addressit(shouldDeferToAddressIt),
       controllers.search(peliasConfig.api, esclient, queries.very_old_prod, oldProdQueryShouldExecute),
+      controllers.search(peliasConfig.api, esclient, queries.fuzzy, oldProdQueryShouldExecute),
       postProc.trimByGranularity(),
       postProc.distances('focus.point.'),
       postProc.localNamingConventions(),

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -292,12 +292,7 @@ function addRoutes(app, peliasConfig) {
       controllers.libpostal(libpostalShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderGeodisambiguationShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderIdsLookupShouldExecute),
-//      controllers.search_with_ids(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderIdsLookupShouldExecute),
-//      controllers.search_with_ids(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
-      // 3rd parameter is which query module to use, use fallback first, then
-      //  use original search strategy if first query didn't return anything
-//      controllers.search(peliasConfig.api, esclient, queries.cascading_fallback, fallbackQueryShouldExecute),
       sanitizers.defer_to_addressit(shouldDeferToAddressIt),
       controllers.search(peliasConfig.api, esclient, queries.very_old_prod, oldProdQueryShouldExecute),
       postProc.trimByGranularity(),
@@ -306,7 +301,6 @@ function addRoutes(app, peliasConfig) {
       postProc.confidenceScores(peliasConfig.api),
       postProc.matchLanguage(peliasConfig.api),
       postProc.interpolate(interpolationService, interpolationShouldExecute),
-//      postProc.sortResponseData(require('pelias-sorting'), hasAdminOnlyResults),
       postProc.dedupe(),
       postProc.accuracy(),
       postProc.translate(),
@@ -322,7 +316,6 @@ function addRoutes(app, peliasConfig) {
       sanitizers.structured_geocoding.middleware(peliasConfig.api),
       middleware.selectLanguage(),
       middleware.calcSize(),
-//      controllers.structured_libpostal(structuredLibpostalService, structuredLibpostalShouldExecute),
       controllers.search(peliasConfig.api, esclient, queries.structured_geocoding, not(hasResponseDataOrRequestErrors)),
       postProc.trimByGranularityStructured(),
       postProc.distances('focus.point.'),

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -230,7 +230,7 @@ function parse(clean) {
 
   // if all we found was regions, ignore it as it is not enough information to make smarter decisions
   if( Object.keys(parsed_text).length === 1 && !_.isUndefined(parsed_text.regions) ){
-    logger.info('Ignoring address parser output, regions only', {
+    logger.debug('AddressIt parsed regions only', {
       parsed: parsed_text,
       params: clean
     });


### PR DESCRIPTION
- Elasticsearch query refactoring to get less trash and to optimize irrelevant query parts
- Two stage adaptive search, which triggers a second fuzzy search if a match was not found
- Symmetrical genitive prefixing: search tuomiorikko finds document name tampereen tuomiokirkko, and search tampereen tuomiokirkko finds document tuomiokirkko, tampere (in previous versions,  only document side was prefixed)
