### PR TITLE
Allow filtering by country in api calls

### DIFF
--- a/sanitizer/_boundary_country.js
+++ b/sanitizer/_boundary_country.js
@@ -6,28 +6,29 @@ function _sanitize(raw, clean) {
   var messages = { errors: [], warnings: [] };
 
   // target input param
-  var country = raw['boundary.country'];
+  var countries = raw['boundary.country'];
 
-  // param 'boundary.country' is optional and should not
-  // error when simply not set by the user
-  if (check.assigned(country)){
-
+  // If explicitly given, parse country codes. If not, set to FIN
+  if (check.assigned(countries)){
     // must be valid string
-    if (!check.nonEmptyString(country)) {
+    if (!check.nonEmptyString(countries)) {
       messages.errors.push('boundary.country is not a string');
+      return messages
     }
 
-    // must be a valid ISO 3166 code
-    else if (!containsIsoCode(country)) {
-      messages.errors.push(country + ' is not a valid ISO2/ISO3 country code');
-    }
+    // every item must be a valid ISO 3166 code
+    var countriesArray = countries.split(",")
+    countriesArray.forEach(country => {
+      if (!containsIsoCode(country)) {
+        messages.errors.push(country + ' is not a valid ISO2/ISO3 country code');
+        return messages;  
+      }
+    })
 
-    // valid ISO 3166 country code, set alpha3 code on 'clean.boundary.country'
-    else {
-      // the only way for boundary.country to be assigned is if input is
-      //  a string and a known ISO2 or ISO3
-      clean['boundary.country'] = iso3166.iso3Code(country);
-    }
+    // The codes are valid, set boundary.country to array of country codes
+    clean['boundary.country'] = countriesArray.map(country => iso3166.iso3Code(country))
+  } else { // default behaviour (set FIN)
+    clean['boundary.country'] = ["FIN"]
   }
 
   return messages;


### PR DESCRIPTION
search_original.js expects an array even though the sanitizer only sanitized strings. Make it so that the sanitizer transforms the parameter strings to arrays, this makes it possible to use for example boundaries.country=FI,EE. If boundaries.country isn't explicitly given, the default is FIN.