### PR TITLE
DT-6005 Search fixes for Estonia

### DIFF
--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -74,6 +74,7 @@
       "sv",
       "en",
       "se",
+      "et",
       "local",
       "alternative",
       "international",

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -116,6 +116,8 @@
       "translations": "/opt/pelias/api/translations.json",
       "equalCharMap": {
         "é":"e",
+        "õ":"ö",
+        "ü":"u",
         "'":"",
         "-":" "
       },


### PR DESCRIPTION
<b>Note, we should support mapping between ü and y as well but seemingly mapping to two different characters is not currently possible.</b>