### PR TITLE
DT-6090 handle unusual use of commas gracefully

### DIFF
--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -96,9 +96,6 @@ function assignValidLibpostalParsing(parsedText, fromLibpostal, text) {
       var addrIndex = parsedText.regions.indexOf(address);
       if (addrIndex > -1) {
         parsedText.regions.splice(addrIndex, 1);
-        if (parsedText.regions.length === 0) {
-          delete parsedText.regions;
-        }
       }
     }
   } else {
@@ -210,8 +207,13 @@ function _sanitize( raw, clean ){
       // remove numbers from admin regions
       parsedText.regions = parsedText.regions.filter(r => !r.match(/^\d/));
     }
-    if (parsedText.regions) {
-      parsedText.admin_parts = parsedText.regions.join(DELIM + ' ');
+
+    if(parsedText.regions) {
+      if(parsedText.regions.length===0) {
+	delete parsedText.regions;
+      } else {
+	parsedText.admin_parts = parsedText.regions.join(DELIM + ' ');
+      }
     }
 
     // remove postalcode from city name
@@ -282,9 +284,6 @@ function parse(clean) {
     parsedText.regions = parsedText.regions.filter(function(value) {
       return(filteredRegions.indexOf(value)===-1);
     });
-    if(parsedText.regions.length===0) {
-      delete parsedText.regions;
-    }
   }
   if(parsedText.regions) {
     // filter region duplicates and validate term count

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -207,6 +207,8 @@ function _sanitize( raw, clean ){
           parsedText.regions[i] = parsedText.regions[i].split(' ').slice(0, MAX_WORDS).join(' ');
         }
       }
+      // remove numbers from admin regions
+      parsedText.regions = parsedText.regions.filter(r => !r.match(/^\d/));
     }
     if (parsedText.regions) {
       parsedText.admin_parts = parsedText.regions.join(DELIM + ' ');


### PR DESCRIPTION
Searches which use comma in unexpected way did not work:

mannerheimintie, 64, helsinki
kamppi, 00100, helsinki

This is now fixed by simply removing names which start with a number from admin regions.